### PR TITLE
Update rspec syntax

### DIFF
--- a/spec/examples/alter_track_spec.rb
+++ b/spec/examples/alter_track_spec.rb
@@ -37,11 +37,11 @@ describe TrackHistory do
     thing.name = 'john2'
     thing.save!
     history = Thing::History.first
-    history.modifications.should == ['name']
-    history.name_from.should == 'john'
-    history.name_to.should == 'john2'
-    history.respond_to?(:name_before).should == false
-    history.respond_to?(:name_after).should == false
+    expect(history.modifications).to eq ['name']
+    expect(history.name_from).to eq 'john'
+    expect(history.name_to).to eq 'john2'
+    expect(history).not_to respond_to(:name_before)
+    expect(history).not_to respond_to(:name_after)
   end
 
 end

--- a/spec/examples/annotation_only_spec.rb
+++ b/spec/examples/annotation_only_spec.rb
@@ -37,15 +37,15 @@ describe TrackHistory do
     user = Beer.create(:name => 'john')
     user.name = 'john2'
     user.save!
-    user.respond_to?(:histories).should == false
+    expect(user.respond_to?(:histories)).to eq false
 
     history = Beer::History.first
-    history.modifications.should == ['name']
-    history.name_before.should == 'john'
-    history.name_after.should == 'john2'
-    history.john.should == 'hi'
-    history.respond_to?(:user).should == false
-    history.respond_to?(:historical_relation).should == false
+    expect(history.modifications).to eq ['name']
+    expect(history.name_before).to eq 'john'
+    expect(history.name_after).to eq 'john2'
+    expect(history.john).to eq 'hi'
+    expect(history).not_to respond_to(:user)
+    expect(history).not_to respond_to(:historical_relation)
   end
 
 end

--- a/spec/examples/annotation_option_spec.rb
+++ b/spec/examples/annotation_option_spec.rb
@@ -38,8 +38,8 @@ describe TrackHistory do
   it 'should be able to alias a field' do
     drink = Drink.create(:name => 'john')
     drink.update_attributes(:name => 'john2')
-    Drink::History.first.respond_to?(:something).should == false
-    Drink::History.first.special.should == 'note'
+    expect(Drink::History.first).not_to respond_to(:something)
+    expect(Drink::History.first.special).to eq 'note'
   end
 
 end

--- a/spec/examples/basic_enum_spec.rb
+++ b/spec/examples/basic_enum_spec.rb
@@ -33,9 +33,9 @@ describe TrackHistory do
   it 'should record an action on create when there is an action field' do
     user = BasicUser.create(:name => 'john')
     history = user.histories.first
-    history.action.should == 'create'
-    history.name_before.should == nil
-    history.name_after.should == 'john'
+    expect(history.action).to eq 'create'
+    expect(history.name_before).to be_nil
+    expect(history.name_after).to eq 'john'
   end
 
   it 'should record an action on update when there is an action field' do
@@ -43,9 +43,9 @@ describe TrackHistory do
     user.update_attributes(:name => 'john2')
 
     history = user.histories.first
-    history.action.should == 'update'
-    history.name_before.should == 'john'
-    history.name_after.should == 'john2'
+    expect(history.action).to eq 'update'
+    expect(history.name_before).to eq 'john'
+    expect(history.name_after).to eq 'john2'
   end
 
   it 'should record an action on destroy when there is an action field' do
@@ -53,11 +53,11 @@ describe TrackHistory do
     user.destroy
 
     history = user.histories.order(:id => 'desc').first
-    history.basic_user_id.should == user.id # make sure the reference is maintained
-    history.action.should == 'destroy'
-    history.name_before.should == 'john'
-    history.name_after.should == nil # we do this for convenience
-    history.modifications.should == ['name']
+    expect(history.basic_user_id).to eq user.id # make sure the reference is maintained
+    expect(history.action).to eq 'destroy'
+    expect(history.name_before).to eq 'john'
+    expect(history.name_after).to be_nil # we do this for convenience
+    expect(history.modifications).to eq ['name']
   end
 
 end

--- a/spec/examples/complex_user_spec.rb
+++ b/spec/examples/complex_user_spec.rb
@@ -45,55 +45,55 @@ describe TrackHistory do
   it 'should automatically annotate with a note on changes' do
     user = ComplexUser.create(:name => 'john')
     user.update_attributes(:name => 'john2')
-    user.histories.first.note.should == NOTE
-    user.histories.first.note2.should == "hello old john"
+    expect(user.histories.first.note).to eq NOTE
+    expect(user.histories.first.note2).to eq "hello old john"
   end
 
   it 'should only affect one field when updating one field, the other should be nil' do
     user = ComplexUser.create(:name => 'john')
     user.update_attributes(:name => 'john2')
 
-    user.histories.first.name_before.should == 'john'
-    user.histories.first.name_after.should == 'john2'
-    user.histories.first.email_before.should == nil
-    user.histories.first.email_after.should == nil
+    expect(user.histories.first.name_before).to eq 'john'
+    expect(user.histories.first.name_after).to eq 'john2'
+    expect(user.histories.first.email_before).to be_nil
+    expect(user.histories.first.email_after).to be_nil
   end
 
   it 'should have the proper modifications when updating 1/2 fields' do
     user = ComplexUser.create(:name => 'john')
     user.update_attributes(:name => 'john2')
-    user.histories.first.modifications.should == ['name']
+    expect(user.histories.first.modifications).to eq ['name']
   end
 
   it 'should have the proper modifications when updating 2/2 fields' do
     user = ComplexUser.create(:name => 'john')
     user.update_attributes(:name => 'john2', :email => 'foo@foo.com')
-    user.histories.first.modifications.sort.should == ['email', 'name']
+    expect(user.histories.first.modifications.sort).to eq ['email', 'name']
   end
 
   it 'should have a good to_s for one field modifications' do
     user = ComplexUser.create(:name => 'john')
     user.update_attributes(:name => 'john2')
-    user.histories.first.to_s.should == 'modified name on user: john2'
+    expect(user.histories.first.to_s).to eq 'modified name on user: john2'
   end
 
   it 'should have a good to_s for two field modifications' do
     user = ComplexUser.create(:name => 'john', :email => 'foo@foo.com')
     user.update_attributes(:name => 'john2', :email => 'foo2@foo2.com')
-    user.histories.first.to_s.should == 'modified email, name on user: john2'
+    expect(user.histories.first.to_s).to eq 'modified email, name on user: john2'
   end
 
   it 'should have a good to_s when moving to nil' do
     user = ComplexUser.create(:name => 'john')
     user.update_attributes(:email => 'foo@foo.com')
-    user.histories.first.to_s.should == 'modified email on user: john'
+    expect(user.histories.first.to_s).to eq 'modified email on user: john'
   end
 
   it 'should be able to take a field from nil to something and record that' do
     user = ComplexUser.create(:name => 'john')
     user.update_attributes(:email => 'foo@foo.com')
-    user.histories.first.email_before.should == nil
-    user.histories.first.email_after.should == 'foo@foo.com'
+    expect(user.histories.first.email_before).to be_nil
+    expect(user.histories.first.email_after).to eq 'foo@foo.com'
   end
 
 end

--- a/spec/examples/different_model_user_spec.rb
+++ b/spec/examples/different_model_user_spec.rb
@@ -47,15 +47,15 @@ describe TrackHistory do
   it 'should work still with a modified model name' do
     user = ModelUser.create(:name => 'john')
     user.update_attributes(:name => 'john2')
-    user.histories.size.should == 1
-    user.histories.first.should be_a(ModelUserAudit)
+    expect(user.histories.size).to eq 1
+    expect(user.histories.first).to be_a(ModelUserAudit)
   end
 
   it 'should work still with a modified table name' do
     user = TableUser.create(:name => 'john')
     user.update_attributes(:name => 'john2')
-    user.histories.size.should == 1
-    user.histories.first.should be_a(TableUser::History) # shouldn't change
+    expect(user.histories.size).to eq 1
+    expect(user.histories.first).to be_a(TableUser::History) # shouldn't change
   end
 
 end

--- a/spec/examples/expand_history_spec.rb
+++ b/spec/examples/expand_history_spec.rb
@@ -37,19 +37,19 @@ describe TrackHistory do
   end
 
   it 'should be able to define class methods' do
-    Door::History.class_note.should == 'class_note'
+    expect(Door::History.class_note).to eq 'class_note'
   end
 
   it 'should be able to define instance methods' do
     door = Door.create(:name => 'john')
     door.update_attributes(:name => 'john2')
-    Door::History.first.instance_note.should == 'instance_note'
+    expect(Door::History.first.instance_note).to eq 'instance_note'
   end
 
   it 'should not have historical_fields as an instance method' do
     door = Door.create(:name => 'john')
     door.update_attributes(:name => 'john2')
-    Door::History.first.should_not respond_to(:historical_fields)
+    expect(Door::History.first).not_to respond_to(:historical_fields)
   end
 
 end

--- a/spec/examples/half_save_spec.rb
+++ b/spec/examples/half_save_spec.rb
@@ -59,16 +59,16 @@ describe TrackHistory do
     user = SlugUser.create(:name => 'john')
     user.update_attributes(:name => 'john2')
     history = user.histories.first
-    history.old_name.should == 'john'
-    history.should_not respond_to(:name_after)
+    expect(history.old_name).to eq 'john'
+    expect(history).not_to respond_to(:name_after)
   end
 
   it 'should be able to save with a hand-made before field named _before and no after field' do
     user = SluggedUser.create(:name => 'john')
     user.update_attributes(:name => 'john2')
     history = user.histories.first
-    history.name_before.should == 'john'
-    history.name_after.should == 'note'
+    expect(history.name_before).to eq 'john'
+    expect(history.name_after).to eq 'note'
   end
 
 end

--- a/spec/examples/no_table_spec.rb
+++ b/spec/examples/no_table_spec.rb
@@ -23,7 +23,7 @@ describe TrackHistory do
   end
 
   it 'should not error out when there is no table for a history model' do
-    AnonUser.should_not respond_to(:historical_fields)
+    expect(AnonUser).not_to respond_to(:historical_fields)
   end
 
 end

--- a/spec/examples/user_spec.rb
+++ b/spec/examples/user_spec.rb
@@ -33,7 +33,7 @@ describe TrackHistory do
   it 'should be able to get the user from :user' do
     user = User.create(:name => 'john')
     user.update_attributes(:name => 'john2')
-    user.histories.first.user == user
+    expect(user.histories.first.user).to eq user
   end
 
   it 'should get the same object when asking for :user or :historical_relation' do
@@ -41,8 +41,8 @@ describe TrackHistory do
     user.update_attributes(:name => 'john2')
     history = user.histories.first
     # check
-    history.user.should_not == nil
-    history.historical_relation.object_id.should == history.user.object_id
+    expect(history.user).not_to eq nil
+    expect(history.historical_relation.object_id).to eq history.user.object_id
   end
 
   it 'should be able to track changes on a simple user model with one field' do
@@ -52,40 +52,40 @@ describe TrackHistory do
     user.name = 'john2'
     user.save
     # check
-    user.histories.first.name_before.should == 'john'
-    user.histories.first.name_after.should == 'john2'
+    expect(user.histories.first.name_before).to eq 'john'
+    expect(user.histories.first.name_after).to eq 'john2'
   end
 
   it 'should be able to accurately list modifications - 1 column' do
     user = User.create(:name => 'john')
     user.update_attributes(:name => 'john2')
-    user.histories.first.modifications.should == ['name']
+    expect(user.histories.first.modifications).to eq ['name']
   end
 
   it 'should not create histories when creating a new object' do
     user = User.create(:name => 'john')
-    user.respond_to?(:historical_fields).should == false
-    user.histories.size.should == 0
+    expect(user.respond_to?(:historical_fields)).to eq false
+    expect(user.histories.size).to eq 0
   end
 
   it 'should not create histories when nothing has changes' do
     user = User.create(:name => 'john')
     user.touch
-    user.histories.size.should == 0
+    expect(user.histories.size).to eq 0
   end
 
   it 'should not create histories when something changed to the same value' do
     user = User.create(:name => 'john')
     user.name = 'john'
     user.save
-    user.histories.size.should == 0
+    expect(user.histories.size).to eq 0
   end
 
   it 'should not update when validations fail' do
     user = User.create(:name => 'john')
     user.name = 'j'
     user.save
-    user.histories.size.should == 0
+    expect(user.histories.size).to eq 0
   end
 
   it 'should be able to work with two user records at the same time and not get confused' do
@@ -95,24 +95,24 @@ describe TrackHistory do
     user1.update_attributes(:name => 'john2')
     user2.update_attributes(:name => 'kate2')
 
-    user1.histories.size.should == 1
-    user1.histories.first.name_before.should == 'john'
-    user1.histories.first.name_after.should == 'john2'
+    expect(user1.histories.size).to eq 1
+    expect(user1.histories.first.name_before).to eq 'john'
+    expect(user1.histories.first.name_after).to eq 'john2'
 
-    user2.histories.size.should == 1
-    user2.histories.first.name_before.should == 'kate'
-    user2.histories.first.name_after.should == 'kate2'
+    expect(user2.histories.size).to eq 1
+    expect(user2.histories.first.name_before).to eq 'kate'
+    expect(user2.histories.first.name_after).to eq 'kate2'
   end
 
   it 'should work with dependent => destroy appropriately' do
     user = User.create(:name => 'john')
     user_id = user.id
     user.update_attributes(:name => 'john2')
-    user.histories.size.should == 1
+    expect(user.histories.size).to eq 1
 
     User.destroy_all
-    User::History.count.should == 1
-    User::History.first.user_id.should == user_id
+    expect(User::History.count).to eq 1
+    expect(User::History.first.user_id).to eq user_id
   end
 
 end


### PR DESCRIPTION
This will remove these warnings when running rspec:
```
Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated
```